### PR TITLE
Cross-section: Mesh without layer automatically set as line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+Useful links 
+============
+
+The PyQt5 and PyQgis documentation is quite scattered, and often we have to
+resort to reading the C++ API or calling ``dir()``. Here is a list of useful
+links which provide some information or examples on how to do things. Below are
+some useful links that helped us develop the plugin and its' test bench.
+
+PyQgis
+------
+
+* [PyQgis API](https://qgis.org/pyqgis/3.16/)
+* [QGIS 3 Cheatsheet](https://github.com/All4Gis/QGIS-cheat-sheet/blob/master/QGIS3.md)
+
+Testing PyQgis
+--------------
+
+* [QGIS plugin testing demo](https://github.com/opengisch/qgis_plugins_test_demo)
+* [Python tests in QGIS repository](https://github.com/qgis/QGIS/tree/master/tests/src/python)
+* [GUI testing PyQt5 with signalspy](https://sharplydescribed.wordpress.com/2020/09/17/gui-qt5-testing-with-python-qsignalspy-qtest/)
+* [QTest in QGIS](https://gis.stackexchange.com/questions/250234/qtest-interactions-with-the-qgis-map-canvas)

--- a/imodqgis/cross_section/cross_section_data.py
+++ b/imodqgis/cross_section/cross_section_data.py
@@ -36,6 +36,8 @@ from .plot_util import (
     project_points_to_section,
 )
 
+from ..utils.layers import NO_LAYERS
+
 WIDTH = 2
 
 
@@ -152,9 +154,13 @@ class MeshLineData(AbstractLineData):
         self.layer_numbers = layer_numbers
         self.x = None
         self.y = None
-        self.variables = np.array(
-            [f"{variable} layer {layer}" for layer in layer_numbers]
-        )
+        if layer_numbers == NO_LAYERS:
+            self.variables = [f"{variable}"]
+        else:
+            self.variables = np.array(
+                [f"{variable} layer {layer}" for layer in layer_numbers]
+            )
+        
         self.pseudocolor_widget = ImodPseudoColorWidget()
         self.unique_color_widget = ImodUniqueColorWidget()
         self.render_style = UNIQUE_COLOR

--- a/imodqgis/cross_section/cross_section_widget.py
+++ b/imodqgis/cross_section/cross_section_widget.py
@@ -50,7 +50,7 @@ from qgis.gui import (
 )
 
 from ..ipf import IpfType, read_associated_borehole
-from ..utils.layers import get_group_names, groupby_variable
+from ..utils.layers import get_group_names, groupby_variable, NO_LAYERS
 from ..widgets import LineGeometryPickerWidget, MultipleVariablesWidget, VariablesWidget
 from .cross_section_data import BoreholeData, MeshData, MeshLineData, RasterLineData
 
@@ -454,6 +454,10 @@ class ImodCrossSectionWidget(QWidget):
         layers = [str(a) for a in self.variables_indexes[variable].keys()]
         self.multi_variable_selection.menu_datasets.populate_actions(layers)
         self.multi_variable_selection.menu_datasets.check_all.setChecked(True)
+
+        if layers == NO_LAYERS:
+            self.as_line_checkbox.setChecked(True)
+            self.as_line_checkbox.setEnabled(False)
 
     def on_geometries_changed(self):
         self.iface.mapCanvas().scene().removeItem(self.rubber_band)

--- a/imodqgis/cross_section/cross_section_widget.py
+++ b/imodqgis/cross_section/cross_section_widget.py
@@ -341,6 +341,13 @@ class ImodCrossSectionWidget(QWidget):
                 self.line_picker.geometries[0].buffer(buffer_distance, 4), None
             )
 
+    def has_top_bottom(self):
+        return (
+            "bottom" in self.self.variables_indexes.keys()
+            ) and (
+            "top" in self.self.variables_indexes.keys()
+            )
+
     def add(self):
         layer = self.layer_selection.currentLayer()
         if layer is None:
@@ -355,6 +362,12 @@ class ImodCrossSectionWidget(QWidget):
                 data = MeshLineData(layer, self.variables_indexes, variable, layers)
                 layer_item = StyleTreeItem(f"{name}: {variable}", "mesh: lines", data)
             else:
+                # Catch case where user provided dataset without "top" or
+                # "bottom" variables in dataset.
+                if not self.has_top_bottom():
+                    raise ValueError(
+                        """Missing "top" and "bottom" variables in dataset."""
+                    )
                 data = MeshData(layer, self.variables_indexes, variable, layers)
                 layer_item = StyleTreeItem(f"{name}: {variable}", "mesh", data)
             self.resolution_spinbox.valueChanged.connect(data.clear)

--- a/imodqgis/utils/layers.py
+++ b/imodqgis/utils/layers.py
@@ -15,6 +15,7 @@ from qgis.core import (
 from collections import defaultdict
 import re
 
+NO_LAYERS = ["0"]
 
 def natural_sort_key(pair, _nsre=re.compile("([0-9]+)")):
     # From: https://stackoverflow.com/questions/4836710/is-there-a-built-in-function-for-string-natural-sort
@@ -33,12 +34,18 @@ def get_group_names(layer):
 
 
 def groupby_variable(group_names, dataset_indexes):
+    EXCEPTED_VARIABLE_NAMES = ["face_x", "face_y"] # Might be further expanded with other UGRID groups.
     grouped = defaultdict(dict)
     for group_name, dataset_idx in zip(group_names, dataset_indexes):
         if "_layer_" in group_name:
             parts = group_name.split("_layer_")
             name, layer_number = parts
             grouped[name][layer_number] = dataset_idx
+        elif group_name not in EXCEPTED_VARIABLE_NAMES:
+            layer_number = NO_LAYERS[0]
+            name = group_name
+            grouped[name][layer_number] = dataset_idx
+
     return grouped
 
 


### PR DESCRIPTION
Automatically set mesh without `"_layer_"` in variable as MeshLineData, similar to approach taken for rasters.

Furthermore throw error if dataset does not contain `"top"` or `"bottom"` variable, but is tried to be drawn as MeshData.

Fixes https://github.com/Deltares/imod-qgis/issues/29
