### PR TITLE
Save color ramps

### DIFF
--- a/imodqgis/utils/color.py
+++ b/imodqgis/utils/color.py
@@ -1,0 +1,36 @@
+from PyQt5.QtGui import QColor
+
+from qgis.core import (
+    QgsGradientStop,
+    QgsGradientColorRamp
+)
+import numpy as np
+
+from typing import List
+
+
+def create_colorramp(
+        boundaries: List[float],
+        colors: List[QColor],
+        discrete: bool = False,
+    ):
+    """
+    Manually construct colorramp from boundaries and colors. The stops
+    determined by the createColorRamp method appear to be broken.
+    """
+
+    # For some reason discrete colormaps require the last color also added as
+    # stop
+    if discrete:
+        indices_stops = slice(1, None)
+    else:
+        indices_stops = slice(1, -1)
+
+    bound_arr = np.array(boundaries)
+    boundaries_norm = (bound_arr-bound_arr[0])/(bound_arr[-1]-bound_arr[0])
+    stops = [
+        QgsGradientStop(stop, color) for stop, color in zip(
+            boundaries_norm[indices_stops], colors[indices_stops]
+        )
+    ]
+    return QgsGradientColorRamp(colors[0], colors[-1], discrete, stops)

--- a/imodqgis/widgets/pseudocolor_widget.py
+++ b/imodqgis/widgets/pseudocolor_widget.py
@@ -277,6 +277,10 @@ class ImodPseudoColorWidget(QWidget):
         return
 
     def save_classes(self):
+        """
+        Save colors to a QGIS colormap textfile. This stores colors and
+        corresponding values.
+        """
         path, _ = QFileDialog.getSaveFileName(self, "Save colormap", "", "*.txt")
         shader = self.shader()
         shader_type = SHADER_TYPES[self.interpolation_box.currentText()]

--- a/imodqgis/widgets/pseudocolor_widget.py
+++ b/imodqgis/widgets/pseudocolor_widget.py
@@ -177,7 +177,7 @@ class ImodPseudoColorWidget(QWidget):
         else:
             return np.nanmax(self.data)
 
-    def set_color_items_in_table(self, boundaries: List, colors: List):
+    def _set_color_items_in_table(self, boundaries: List, colors: List):
         self.table.clear()
         for boundary, color in zip(boundaries, colors):
             new_item = QgsTreeWidgetItemObject(self.table)
@@ -213,7 +213,7 @@ class ImodPseudoColorWidget(QWidget):
                 boundaries = np.linspace(self.minimum(), self.maximum(), n_class)
 
         colors = [ramp.color(f) for f in np.linspace(0.0, 1.0, n_class)]
-        self.set_color_items_in_table(boundaries, colors)
+        self._set_color_items_in_table(boundaries, colors)
 
     def format_labels(self):
         shader_type = SHADER_TYPES[self.interpolation_box.currentText()]
@@ -279,7 +279,7 @@ class ImodPseudoColorWidget(QWidget):
             raise ValueError(f"Encountered the following errors while parsing color map file: {load_errors}")
         boundaries = [color_ramp_item.value for color_ramp_item in color_ramp_items]
         colors = [color_ramp_item.color for color_ramp_item in color_ramp_items]
-        self.set_color_items_in_table(boundaries, colors)
+        self._set_color_items_in_table(boundaries, colors)
         colorramp = self._create_colorramp(boundaries, colors)
         self.color_ramp_button.setColorRamp(colorramp)
         return

--- a/imodqgis/widgets/pseudocolor_widget.py
+++ b/imodqgis/widgets/pseudocolor_widget.py
@@ -263,12 +263,15 @@ class ImodPseudoColorWidget(QWidget):
 
     def load_classes(self):
         path, _ = QFileDialog.getOpenFileName(self, "Load colormap", "", "*.txt")
-        load_succeeded, color_ramp_items, shader_type, load_errors = QgsRasterRendererUtils.parseColorMapFile(path)
+        # Load colorsmap
+        load_succeeded, color_ramp_items, _, load_errors = QgsRasterRendererUtils.parseColorMapFile(path)
         if not load_succeeded:
             raise ValueError(f"Encountered the following errors while parsing color map file: {load_errors}")
-        boundaries = [color_ramp_item.value for color_ramp_item in color_ramp_items]
-        colors = [color_ramp_item.color for color_ramp_item in color_ramp_items]
+        # Unpack values
+        boundaries, colors = zip(*[(c_ramp_item.value, c_ramp_item.color) for c_ramp_item in color_ramp_items])
+        # Set color items in table
         self._set_color_items_in_table(boundaries, colors)
+        # Set color ramp
         colorramp = create_colorramp(boundaries, colors, discrete=False)
         self.color_ramp_button.setColorRamp(colorramp)
         return

--- a/imodqgis/widgets/pseudocolor_widget.py
+++ b/imodqgis/widgets/pseudocolor_widget.py
@@ -266,6 +266,9 @@ class ImodPseudoColorWidget(QWidget):
         boundaries = [color_ramp_item.value for color_ramp_item in color_ramp_items]
         colors = [color_ramp_item.color for color_ramp_item in color_ramp_items]
         self.set_color_items_in_table(boundaries, colors)
+
+        colorramp = self.shader().createColorRamp()
+        self.color_ramp_button.setColorRamp(colorramp)
         return
 
     def save_classes(self):

--- a/imodqgis/widgets/pseudocolor_widget.py
+++ b/imodqgis/widgets/pseudocolor_widget.py
@@ -23,6 +23,8 @@ from PyQt5.QtWidgets import (
 )
 from qgis.core import (
     QgsColorRampShader,
+    QgsGradientColorRamp,
+    QgsGradientStop,
     QgsRasterRendererUtils
 )
 from qgis.gui import (
@@ -258,6 +260,18 @@ class ImodPseudoColorWidget(QWidget):
         for item in self.table.selectedItems():
             self.table.takeTopLevelItem(self.table.indexOfTopLevelItem(item))
 
+    def _create_colorramp(self, boundaries, colors):
+        # Manually construct colorramp from colorrampshader. The stops
+        # determined by the createColorRamp method appear to be broken.
+        bound_arr = np.array(boundaries)
+        boundaries_norm = (bound_arr-bound_arr[0])/(bound_arr[-1]-bound_arr[0])
+        stops = [
+            QgsGradientStop(stop, color) for stop, color in zip(
+                boundaries_norm[1:-1], colors[1:-1]
+            )
+        ]
+        return QgsGradientColorRamp(colors[0], colors[-1], False, stops)      
+
     def load_classes(self):
         path, _ = QFileDialog.getOpenFileName(self, "Load colormap", "", "*.txt")
         load_succeeded, color_ramp_items, shader_type, load_errors = QgsRasterRendererUtils.parseColorMapFile(path)
@@ -266,8 +280,7 @@ class ImodPseudoColorWidget(QWidget):
         boundaries = [color_ramp_item.value for color_ramp_item in color_ramp_items]
         colors = [color_ramp_item.color for color_ramp_item in color_ramp_items]
         self.set_color_items_in_table(boundaries, colors)
-
-        colorramp = self.shader().createColorRamp()
+        colorramp = self._create_colorramp(boundaries, colors)
         self.color_ramp_button.setColorRamp(colorramp)
         return
 

--- a/imodqgis/widgets/pseudocolor_widget.py
+++ b/imodqgis/widgets/pseudocolor_widget.py
@@ -32,6 +32,7 @@ from qgis.gui import (
     QgsColorSwatchDelegate,
     QgsTreeWidgetItemObject,
 )
+from imodqgis.utils.color import create_colorramp
 
 
 Number = Union[int, float]
@@ -260,18 +261,6 @@ class ImodPseudoColorWidget(QWidget):
         for item in self.table.selectedItems():
             self.table.takeTopLevelItem(self.table.indexOfTopLevelItem(item))
 
-    def _create_colorramp(self, boundaries, colors):
-        # Manually construct colorramp from colorrampshader. The stops
-        # determined by the createColorRamp method appear to be broken.
-        bound_arr = np.array(boundaries)
-        boundaries_norm = (bound_arr-bound_arr[0])/(bound_arr[-1]-bound_arr[0])
-        stops = [
-            QgsGradientStop(stop, color) for stop, color in zip(
-                boundaries_norm[1:-1], colors[1:-1]
-            )
-        ]
-        return QgsGradientColorRamp(colors[0], colors[-1], False, stops)      
-
     def load_classes(self):
         path, _ = QFileDialog.getOpenFileName(self, "Load colormap", "", "*.txt")
         load_succeeded, color_ramp_items, shader_type, load_errors = QgsRasterRendererUtils.parseColorMapFile(path)
@@ -280,7 +269,7 @@ class ImodPseudoColorWidget(QWidget):
         boundaries = [color_ramp_item.value for color_ramp_item in color_ramp_items]
         colors = [color_ramp_item.color for color_ramp_item in color_ramp_items]
         self._set_color_items_in_table(boundaries, colors)
-        colorramp = self._create_colorramp(boundaries, colors)
+        colorramp = create_colorramp(boundaries, colors, discrete=False)
         self.color_ramp_button.setColorRamp(colorramp)
         return
 

--- a/imodqgis/widgets/unique_color_widget.py
+++ b/imodqgis/widgets/unique_color_widget.py
@@ -131,7 +131,7 @@ class ImodUniqueColorWidget(QWidget):
         uniques = pd.Series(self.data).dropna().unique()
         n_class = uniques.size
         ramp = self.color_ramp_button.colorRamp()
-        if ramp.type in ["colorbrewer", "random"]:
+        if ramp.type() in ["colorbrewer", "random"]:
             n_colors = ramp.count()
             values_colors = self._get_cyclic_normalized_midpoints(n_class, n_colors)
         else:

--- a/imodqgis/widgets/unique_color_widget.py
+++ b/imodqgis/widgets/unique_color_widget.py
@@ -131,13 +131,11 @@ class ImodUniqueColorWidget(QWidget):
         uniques = pd.Series(self.data).dropna().unique()
         n_class = uniques.size
         ramp = self.color_ramp_button.colorRamp()
-        n_colors = ramp.count()
-        # Cap n_colors at max 12, as for example some gradient colormaps have
-        # 255 stops. Too high values for n_colors create too subtle color
-        # shifts.
-        n_colors = np.min([n_colors, 12])
-
-        values_colors = self._get_cyclic_normalized_midpoints(n_class, n_colors)
+        if ramp.type in ["colorbrewer", "random"]:
+            n_colors = ramp.count()
+            values_colors = self._get_cyclic_normalized_midpoints(n_class, n_colors)
+        else:
+            values_colors = np.linspace(0.0, 1.0, n_class)
         return [ramp.color(f) for f in values_colors]
 
     def classify(self) -> None:

--- a/imodqgis/widgets/unique_color_widget.py
+++ b/imodqgis/widgets/unique_color_widget.py
@@ -122,7 +122,7 @@ class ImodUniqueColorWidget(QWidget):
         """
         return ((np.arange(n_elements) % cycle_size) + 0.5) / cycle_size
 
-    def needs_cyclic_colorramp(self):
+    def _needs_cyclic_colorramp(self):
         ramp = self.color_ramp_button.colorRamp()
         if ramp.type() in ["colorbrewer", "random"]:
             return True
@@ -131,9 +131,11 @@ class ImodUniqueColorWidget(QWidget):
         else:
             return False
 
-    def count_discrete_colors(self):
-        """The discrete gradient has one stop more than colors, whereas the
-        colorbrewer colorramp has as many stops as colors"""
+    def _count_discrete_colors(self):
+        """
+        The discrete gradient has one stop more than colors, whereas the
+        colorbrewer colorramp has as many stops as colors
+        """
         ramp = self.color_ramp_button.colorRamp()
         if ramp.type() in ["gradient"]:
             return ramp.count() - 1
@@ -144,8 +146,8 @@ class ImodUniqueColorWidget(QWidget):
         uniques = pd.Series(self.data).dropna().unique()
         n_class = uniques.size
         ramp = self.color_ramp_button.colorRamp()
-        if self.needs_cyclic_colorramp():
-            n_colors = self.count_discrete_colors()
+        if self._needs_cyclic_colorramp():
+            n_colors = self._count_discrete_colors()
             values_colors = self._get_cyclic_normalized_midpoints(n_class, n_colors)
         else:
             values_colors = np.linspace(0.0, 1.0, n_class)

--- a/imodqgis/widgets/unique_color_widget.py
+++ b/imodqgis/widgets/unique_color_widget.py
@@ -182,7 +182,7 @@ class ImodUniqueColorWidget(QWidget):
             self.table.takeTopLevelItem(self.table.indexOfTopLevelItem(item))
 
     def load_classes(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Load colors", "", "*.txt")
+        path, _ = QFileDialog.getOpenFileName(self, "Load colors", "", "*.json")
         with open(path, "r") as file:
             rgb_values = json.load(file)
         self.loaded_colors = [QColor(*rgb) for rgb in rgb_values]
@@ -193,12 +193,19 @@ class ImodUniqueColorWidget(QWidget):
             item.setData(1, Qt.ItemDataRole.EditRole, color)
 
     def save_classes(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(self, "Save colors", "", "*.txt")
+        """
+        Save colors to a .json file. The unique color widget saves only colors
+        without corresponding values, as values are usually too unique (e.g.
+        name of borehole) to be used for different datasets. QGIS has no
+        standard functionality for writing purely colors to file, hence we save
+        to a json.
+        """
+        path, _ = QFileDialog.getSaveFileName(self, "Save colors", "", "*.json")
         colors = self.colors().values()
         rgb_values = [c.getRgb() for c in colors]
 
         with open(path, "w") as file:
-            file.write(json.dumps(rgb_values))
+            json.dump(rgb_values, file)
 
     def shader(self) -> ImodUniqueColorShader:
         values = []

--- a/imodqgis/widgets/unique_color_widget.py
+++ b/imodqgis/widgets/unique_color_widget.py
@@ -115,17 +115,17 @@ class ImodUniqueColorWidget(QWidget):
                 Qt.ItemIsEnabled | Qt.ItemIsEditable | Qt.ItemIsSelectable
             )
 
-    def _get_tiled_normalized_midpoints(self, n_elements, tilesize):
+    def _get_cyclic_normalized_midpoints(self, n_elements, cycle_size):
         """
-        Create array with length n_class of rolling normalized midpoint values
-        which can be used to to fetch values on unique colors colormap.
+        Create array with length n_elements which cycles through normalized
+        midpoint values, used to fetch values on unique colors colormap.
 
         Example
         -------
-        >>> self._get_tiled_normalized_midpoints(n_elements=6, tilesize=4)
+        >>> self._get_cyclic_normalized_midpoints(n_elements=6, cycle_size=4)
         array([0.125, 0.375, 0.625, 0.875, 0.125, 0.375)]
         """
-        return ((np.arange(n_elements) % tilesize) + 0.5) / tilesize
+        return ((np.arange(n_elements) % cycle_size) + 0.5) / cycle_size
 
     def get_colors_from_ramp_button(self) -> List[QColor]:
         uniques = pd.Series(self.data).dropna().unique()
@@ -137,7 +137,7 @@ class ImodUniqueColorWidget(QWidget):
         # shifts.
         n_colors = np.min([n_colors, 12])
 
-        values_colors = self._get_tiled_normalized_midpoints(n_class, n_colors)
+        values_colors = self._get_cyclic_normalized_midpoints(n_class, n_colors)
         return [ramp.color(f) for f in values_colors]
 
     def classify(self) -> None:

--- a/imodqgis/widgets/unique_color_widget.py
+++ b/imodqgis/widgets/unique_color_widget.py
@@ -5,11 +5,13 @@ from typing import Dict
 
 import numpy as np
 import pandas as pd
+import json
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
+    QFileDialog,
     QLabel,
     QPushButton,
     QTreeWidget,
@@ -83,9 +85,12 @@ class ImodUniqueColorWidget(QWidget):
         layout.addLayout(second_row)
         self.setLayout(layout)
 
-    def set_data(self, data: np.ndarray):
+    def set_data(self, data: np.ndarray) -> None:
         self.data = data
         self.classify()
+
+    def set_legend(self) -> None:
+
 
     def classify(self) -> None:
         self.table.clear()
@@ -143,10 +148,23 @@ class ImodUniqueColorWidget(QWidget):
             self.table.takeTopLevelItem(self.table.indexOfTopLevelItem(item))
 
     def load_classes(self) -> None:
-        pass
+        path, _ = QFileDialog.getOpenFileName(self, "Load colors", "", "*.txt")
+        with open(path, "r") as file:
+            rgb_values = json.load(file)
+        colors = [QColor(*rgb) for rgb in rgb_values]
+        table_iter = range(self.table.topLevelItemCount())
+
+        for i, color in zip(table_iter, colors):
+            item = self.table.topLevelItem(i)
+            item.setData(1, Qt.ItemDataRole.EditRole, color)
 
     def save_classes(self) -> None:
-        pass
+        path, _ = QFileDialog.getSaveFileName(self, "Save colors", "", "*.txt")
+        colors = self.colors().values()
+        rgb_values = [c.getRgb() for c in colors]
+
+        with open(path, "w") as file:
+            file.write(json.dumps(rgb_values))
 
     def shader(self) -> ImodUniqueColorShader:
         values = []

--- a/imodqgis/widgets/unique_color_widget.py
+++ b/imodqgis/widgets/unique_color_widget.py
@@ -132,6 +132,10 @@ class ImodUniqueColorWidget(QWidget):
         n_class = uniques.size
         ramp = self.color_ramp_button.colorRamp()
         n_colors = ramp.count()
+        # Cap n_colors at max 12, as for example some gradient colormaps have
+        # 255 stops. Too high values for n_colors create too subtle color
+        # shifts.
+        n_colors = np.min([n_colors, 12])
 
         values_colors = self._get_tiled_normalized_midpoints(n_class, n_colors)
         return [ramp.color(f) for f in values_colors]


### PR DESCRIPTION
Fix https://github.com/Deltares/imod-qgis/issues/49

Implement loading and saving of colors. UniqueColorWidget behaves differently than PseudoColor

**PseudoColorWidget** 

- Colormap is saved in colormap file, using QgsRasterRendererUtils. This stores colors and corresponding values.

**UniqueColorWidget** 

- Classify is no longer called with each selection change.
- Only colors saved in json text file, as values are often very unique (e.g. name of borehole), where the user is expected only to be interested in loading colors. In this case colors are loaded and set as the colorramp.
- When n_colors exceeds n_unique_values, colors are cycled instead of repeated. For example if n_colors = 3, n_unique_values = 5, formerly this would return _[red, red, blue, green, green]_, this changeset returns _[red, blue, green, red, blue]_.