### PR TITLE
Timeseries widget: Test if layerChanged is connected before trying to disconnect

### DIFF
--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -319,6 +319,12 @@ class ImodTimeSeriesWidget(QWidget):
                     pass
         QWidget.hideEvent(self, e)
 
+    def showEvent(self, e):
+        layer = self.layer_selection.currentLayer()
+        if (layer is not None) and (layer.type() == QgsMapLayerType.VectorLayer):
+            layer.selectionChanged.connect(self.on_select)
+        QWidget.showEvent(self, e)
+
     def clear_plot(self):
         self.plot_widget.clear()
         self.legend.clear()


### PR DESCRIPTION
Fixes #54 , there is a bug where for vector data the plugin attempted to disconnect the layerChanged signal, but threw an error because nothing was connect to this signal. 

To reproduce this issue:
- Select vector data in timeseries widget
- Hide QGIS
- Unhide QGIS
- Hide QGIS

In my experience, the ``signalspy`` is the easiest way to track whether things are connected to a signal or not.