### PR TITLE
Don't error if Arrow files don't exist or are empty

### DIFF
--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -550,8 +550,9 @@ class ImodTimeSeriesWidget(QWidget):
         column = layer.customProperty("arrow_fid_column")
         if Path(arrow_path).is_file():
             df = read_arrow(arrow_path)
-            for key, groupdf in df.groupby(column):
-                self.stored_dataframes[key] = groupdf.set_index("time")
+            if not df.empty:
+                for key, groupdf in df.groupby(column):
+                    self.stored_dataframes[key] = groupdf.set_index("time")
         return
 
     def sync_arrow_data(self, layer):

--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -466,7 +466,7 @@ class ImodTimeSeriesWidget(QWidget):
                     sample_df = next(iter(self.stored_dataframes.values()))
                 else:
                     sample_df = pd.DataFrame()
-                variables = list(sample_df.columns)
+                variables = sample_df.select_dtypes(include=["float"]).columns.tolist()
                 self.id_selection_box.insertItem(0, "fid")
                 self.id_selection_box.setEnabled(False)
             else:

--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -548,8 +548,10 @@ class ImodTimeSeriesWidget(QWidget):
         """Synchronize timeseries data from an Arrow dataset"""
         arrow_path = layer.customProperty("arrow_path")
         column = layer.customProperty("arrow_fid_column")
+        # Don't crash if Ribasim did not yet run
         if Path(arrow_path).is_file():
             df = read_arrow(arrow_path)
+            # Don't crash if the dataframe is empty
             if not df.empty:
                 for key, groupdf in df.groupby(column):
                     self.stored_dataframes[key] = groupdf.set_index("time")

--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -7,7 +7,7 @@ Widget for displaying timeseries data.
 In general: plotting with pyqtgraph is fast, collecting data is relatively
 slow.
 """
-import pathlib
+from pathlib import Path
 import tempfile
 from itertools import compress
 
@@ -462,7 +462,10 @@ class ImodTimeSeriesWidget(QWidget):
                 variables = layer.customProperty("ipf_assoc_columns").split("␞")
             elif layer.customProperty("arrow_type") == "timeseries":
                 self.load_arrow_data(layer)
-                sample_df = next(iter(self.stored_dataframes.values()))
+                if self.stored_dataframes:
+                    sample_df = next(iter(self.stored_dataframes.values()))
+                else:
+                    sample_df = pd.DataFrame()
                 variables = list(sample_df.columns)
                 self.id_selection_box.insertItem(0, "fid")
                 self.id_selection_box.setEnabled(False)
@@ -521,7 +524,7 @@ class ImodTimeSeriesWidget(QWidget):
         index = int(layer.customProperty("ipf_indexcolumn"))
         ext = layer.customProperty("ipf_assoc_ext")
         ipf_path = layer.customProperty("ipf_path")
-        parent = pathlib.Path(ipf_path).parent
+        parent = Path(ipf_path).parent
         names = sorted(
             [str(layer.getFeature(fid).attribute(index)) for fid in feature_ids]
         )
@@ -545,9 +548,10 @@ class ImodTimeSeriesWidget(QWidget):
         """Synchronize timeseries data from an Arrow dataset"""
         arrow_path = layer.customProperty("arrow_path")
         column = layer.customProperty("arrow_fid_column")
-        df = read_arrow(arrow_path)
-        for key, groupdf in df.groupby(column):
-            self.stored_dataframes[key] = groupdf.set_index("time")
+        if Path(arrow_path).is_file():
+            df = read_arrow(arrow_path)
+            for key, groupdf in df.groupby(column):
+                self.stored_dataframes[key] = groupdf.set_index("time")
         return
 
     def sync_arrow_data(self, layer):
@@ -592,7 +596,7 @@ class ImodTimeSeriesWidget(QWidget):
             return
 
         with tempfile.TemporaryDirectory() as parent:
-            path = pathlib.Path(parent) / "temp-table.csv"
+            path = Path(parent) / "temp-table.csv"
             write_csv(layer, path)
             df = pd.read_csv(
                 path,


### PR DESCRIPTION
Fix #64.

When opening a Ribasim model and you don't know there is no output yet, but click the time series widget, you get an error that is hard to understand.

This changes the code to not load any data, such that the widget still opens but there are no variables to select. If you then run the model and load the widget again the results do appear. It is better than the current behavior, though I'm also open to other ways to handle this.

This was the error when it did not exist:

```
AttributeError: 'NoneType' object has no attribute 'GetLayer' 
Traceback (most recent call last):
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\imodqgis\imod_plugin.py", line 132, in toggle_timeseries
    widget = ImodTimeSeriesWidget(self.timeseries_widget, self.iface)
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\imodqgis\timeseries\timeseries_widget.py", line 284, in __init__
    self.on_layer_changed()
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\imodqgis\timeseries\timeseries_widget.py", line 464, in on_layer_changed
    self.load_arrow_data(layer)
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\imodqgis\timeseries\timeseries_widget.py", line 548, in load_arrow_data
    df = read_arrow(arrow_path)
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\imodqgis\arrow\reading.py", line 7, in read_arrow
    layer = dataset.GetLayer(0)
AttributeError: 'NoneType' object has no attribute 'GetLayer'
```

And when it was empty it got a KeyError for `edge_id` in the groupby.
