### PR TITLE
Add secondary encoding (cp1252) to GEF reader

### DIFF
--- a/imodqgis/gef/reading.py
+++ b/imodqgis/gef/reading.py
@@ -206,11 +206,16 @@ class CptGefFile:
         return f"{self.__class__.__name__}(nr={self.nr})"
 
     def __open_file(self, path):
-        with open(path, "r") as f:
-            text = f.read()
-            end_header = re.search(r"(?P<eoh>#EOH[=\s+]+)", text).group("eoh")
+        try:
+            with open(path, "r") as f:
+                text = f.read()
+        except UnicodeDecodeError:
+            with open(path, "r", encoding='cp1252') as f:
+                text = f.read()
+            
+        end_header = re.search(r"(?P<eoh>#EOH[=\s+]+)", text).group("eoh")
 
-            self._header, self._data = text.split(end_header)
+        self._header, self._data = text.split(end_header)
 
         self.parse_header()
         self.parse_data()


### PR DESCRIPTION
If the GEF file cannot be read with the default encoding (UTF8) it will fall back onto the cp1252 encoding. This helps to accept GEF files as commonly produced by dutch suppliers.

For more description of the problem, see: https://github.com/Deltares/GEOLib-Plus/issues/6#issue-1329605905