### PR TITLE
Don't force `useOpenGL = True`

### DIFF
--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -83,13 +83,7 @@ def timeseries_y_data(layer, geometry, group_index, n_times):
     return y
 
 
-# Set rendering backend and set pen widths
-# NOTE: DO NOT USE PEN WIDTHS > 1 WITHOUT OPENGL, THIS IS EXTREMELY SLOW
-# This is due to an upstream issue with the Qt raster painting system:
-# https://www.qcustomplot.com/index.php/support/forum/1008
-# Setting useOpenGL will presumably use OpenGL's raster painting instead, which
-# has good performance, but does not seem to support anti-aliasing.
-pg.setConfigOptions(useOpenGL=True)
+# Set pen widths
 WIDTH = 2
 SELECTED_WIDTH = 3
 # pyqtgraph expects datetimes expressed as seconds from 1970-01-01


### PR DESCRIPTION
Fixes https://github.com/Deltares/imod-qgis/issues/82. I mentioned there earlier that this didn't always work, but that was mostly people telling me, and perhaps they applied the workaround incorrectly. Recently whenever I've watched people apply the workaround it always worked.

Workaround:

```py
import imodqgis; imodqgis.dependencies.pyqtgraph_0_12_3.setConfigOptions(useOpenGL=False)
```

This setting was introduced by @Huite in https://github.com/Deltares/imod-qgis/commit/899753fd3ab3e6510f0a1ce409f22b735520782d, stating "fix performance issue by enabling OpenGL".

Pyqtgraph defaults to False on all platforms because True is buggy:

https://github.com/Deltares/imod-qgis/blob/24789dae49d51b5b927245ef579ee2fea385829f/imodqgis/dependencies/pyqtgraph_0_12_3/__init__.py#L25-L36

I had a look at [qgis-crayfish-plugin](https://github.com/lutraconsulting/qgis-crayfish-plugin) and they also stick to the defaults.

I created a run with very dense data, and with plotting 100_000 datapoints this is still snappy, so perhaps some of the performance issues without OpenGL have since been fixed. Especially this note:

```
NOTE: DO NOT USE PEN WIDTHS > 1 WITHOUT OPENGL, THIS IS EXTREMELY SLOW
```

I kept the pen width at 2, but didn't experience extreme slowness. But perhaps it is good if @Huite or @JoerivanEngelen confirms for their typical plotting workflow.