### PR TITLE
Set active layer in timeseries widget

### DIFF
--- a/imodqgis/metadata.txt
+++ b/imodqgis/metadata.txt
@@ -30,7 +30,13 @@ repository=https://github.com/Deltares/imod-qgis
 hasProcessingProvider=no
 
 # Uncomment the following line and add your changelog:
-changelog=      <p>0.5.3 - Bug fixes
+changelog=      <p>Unreleased - Usability improvements
+                - Timeseries: Selecting a a layer in the listing box will now
+                  also select it in the QGIS Layers panel, irregardless of type.
+                  Before this only worked for vectors.
+                - Timeseries: Clicking the "Select" button will now also select the
+                  layer that is shown in the listing box in the QGIS Layers panel.
+                <p>0.5.3 - Bug fixes
                 - Added secondary encoding (cp1252) to GEF reader.
                 - Don't force useOpenGL = True for pyqtgraph. In general openGL is poorly supported with Qt+GraphicsView. 
                 <p>0.5.2 - Bug fixes

--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -417,6 +417,9 @@ class ImodTimeSeriesWidget(QWidget):
         self.variables_indexes = None
         self.variable_selection.setVisible(False)
         self.id_selection_box.clear()
+        # Set active layer so the Selection Toolbar will work as expected (since
+        # it works on the currently active layer for vectors). 
+        self.iface.setActiveLayer(layer)
         if layer.type() == QgsMapLayerType.MeshLayer:
             indexes, names = get_group_names(layer)
             is_temporal = get_group_is_temporal(layer)
@@ -449,9 +452,6 @@ class ImodTimeSeriesWidget(QWidget):
         elif layer.type() == QgsMapLayerType.VectorLayer:
             # Connect to QGIS signal that selection changed
             layer.selectionChanged.connect(self.on_select)
-            # Set active layer so the Selection Toolbar will work as expected
-            # (since it works on the currently active layer)
-            self.iface.setActiveLayer(layer)
             if layer.customProperty("ipf_type") == IpfType.TIMESERIES.name:
                 index = int(layer.customProperty("ipf_indexcolumn"))
                 self.id_selection_box.insertItem(0, layer.attributeAlias(index))

--- a/imodqgis/timeseries/timeseries_widget.py
+++ b/imodqgis/timeseries/timeseries_widget.py
@@ -348,6 +348,8 @@ class ImodTimeSeriesWidget(QWidget):
         layer = self.layer_selection.currentLayer()
         if layer is None:
             return
+        # Set active layer so the selection will target the expected layer
+        self.iface.setActiveLayer(layer)
         if layer.type() == QgsMapLayerType.MeshLayer:
             self.point_picker.picker_clicked()
         else:


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2719.

I tested this locally and it works as I intended.

The active layer is always set when clicking the Select button. It is also set when changing the layer in the timeseries widget, or when opening the widget. I think that is fine, but I wanted to mention it.